### PR TITLE
Dual funding proposed codec updates

### DIFF
--- a/09-features.md
+++ b/09-features.md
@@ -41,7 +41,7 @@ The Context column decodes as follows:
 | 20/21 | `option_anchor_outputs`          | Anchor outputs                                            | IN       | `option_static_remotekey` | [BOLT #3](03-transactions.md)         |
 | 22/23 | `option_anchors_zero_fee_htlc_tx` | Anchor commitment type with zero fee HTLC transactions   | IN       |                   | [BOLT #3][bolt03-htlc-tx], [lightning-dev][ml-sighash-single-harmful]|
 | 26/27 | `option_shutdown_anysegwit`         | Future segwit versions allowed in `shutdown`              | IN       |                   | [BOLT #2][bolt02-shutdown]   |
-| 28/29 | `option_dual_fund`             | Use v2 of channel open, enables dual funding              | IN      | `option_anchor_outputs`, `option_static_remotekey`   | [BOLT #2](02-peer-protocol.md)        |
+| 28/29 | `option_dual_fund`             | Use v2 of channel open, enables dual funding              | IN      | `option_anchors_zero_fee_htlc_tx`   | [BOLT #2](02-peer-protocol.md)        |
 
 ## Requirements
 


### PR DESCRIPTION
This commit is added on top of @niftynei dual funding branch and contains the following proposed changes:

* Move RBF inside the `interactive-tx` protocol: other protocols (e.g. splicing) will need it as well, so it's weird to have it only defined in the channel open flow
* Harmonize tlvs between v1 and v2 of `open_channel` and `accept_channel` (we probably need a rebase on `master` to import the `channel_type` tlv)
* Require use of native segwit
* Fix a few typos/whitespaces issues (thanks markdown linter)

It's actually not so many changes, you probably won't hate me too much :)